### PR TITLE
Correct name from Fei to Fe

### DIFF
--- a/_posts/2021-04-02-FuzzyVM.md
+++ b/_posts/2021-04-02-FuzzyVM.md
@@ -23,7 +23,7 @@ This issue resulted in most block explorers being stuck.
 Fortunately the issue was quickly resolved and the nodes were updated to follow the [canonical chain](https://www.coindesk.com/open-ethereum-clients-error-berlin).
 
 The EVM is an integral part of an Ethereum node as it executes the state transition.
-Smart Contracts in Ethereum are usually written in a high level language like Solidity, Vyper or Fei.
+Smart Contracts in Ethereum are usually written in a high level language like Solidity, Vyper or Fe.
 The high level language gets compiled to EVM bytecode which is deployed on-chain.
 This EVM bytecode is executed if a transaction is send to the contract.
 The EVM provides over 80 Opcodes (like ADD, SUB, CALL) as well as 9 complex functions as precompiled contracts.


### PR DESCRIPTION
Great post! Thanks for giving Fe a shout out! I send a fix for the name, it is spelled "Fe" like the chemical element for iron. 